### PR TITLE
Update Java binary size to include Graal binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 ## Currently implemented languages (sorted by charcount):
 
-| Language  | Charcount | Binary size |
-|-----------|:---------:|------------:|
-| Assembler |    10     |        4640 |
-| C(tcc)    |    24     |        2844 |
-| Rust      |    68     |     3636672 |
-| Java      |    196    |     605+JVM |
+| Language  | Charcount | Binary size                 |
+|-----------|:---------:|----------------------------:|
+| Assembler |    10     |                         4640|
+| C(tcc)    |    24     |                         2844|
+| Rust      |    68     |                      3636672|
+| Java      |    196    | 605+JVM  / ~14.6 MiB (Graal)|


### PR DESCRIPTION
This pull request adds information about the rough size of a binary executable built from `ts.java` using GraalVM CE for Java 17 (21.3.0) on AMD64 Linux